### PR TITLE
Automatically determine and use real bitwindow after start

### DIFF
--- a/ZACwire.h
+++ b/ZACwire.h
@@ -107,7 +107,6 @@ class ZACwire {
 		static void attachISR_ESP32(void*){					//attach ISR in freeRTOS because gcc 5.3+ can't put ISR in IRAM inside of template class
 			gpio_num_t isrPin = (gpio_num_t)pin;
 			gpio_pad_select_gpio(isrPin);
-			gpio_set_direction((gpio_num_t)isrPin, GPIO_MODE_INPUT);
 			gpio_set_intr_type(isrPin, GPIO_INTR_POSEDGE);
 			gpio_install_isr_service(0);
 			gpio_isr_handler_add(isrPin, read, NULL);
@@ -138,7 +137,8 @@ class ZACwire {
 				else {
 					if (bitCounter == 10) microtime += bitWindow>>2;	//convert timestamp at stop bit to normal 0 bit
 					rawData[backUP] <<= 1;
-					rawData[backUP] |= bitWindow > deltaTime + ((rawData[backUP] & 2)?0:(bitWindow>>1));	//add 1/2 bitWindow if previous bit was 1 (for normalisation)
+					if (rawData[backUP] & 2) deltaTime += bitWindow >> 1;   //add 1/2 bitWindow if previous bit was 1
+					rawData[backUP] |= bitWindow > deltaTime;
 				}
 				deltaTime = microtime;
 			}

--- a/ZACwire.h
+++ b/ZACwire.h
@@ -107,6 +107,7 @@ class ZACwire {
 		static void attachISR_ESP32(void*){					//attach ISR in freeRTOS because gcc 5.3+ can't put ISR in IRAM inside of template class
 			gpio_num_t isrPin = (gpio_num_t)pin;
 			gpio_pad_select_gpio(isrPin);
+			gpio_set_direction((gpio_num_t)isrPin, GPIO_MODE_INPUT);
 			gpio_set_intr_type(isrPin, GPIO_INTR_POSEDGE);
 			gpio_install_isr_service(0);
 			gpio_isr_handler_add(isrPin, read, NULL);
@@ -137,8 +138,7 @@ class ZACwire {
 				else {
 					if (bitCounter == 10) microtime += bitWindow>>2;	//convert timestamp at stop bit to normal 0 bit
 					rawData[backUP] <<= 1;
-					if (rawData[backUP] & 2) deltaTime += bitWindow >> 1;   //add 1/2 bitWindow if previous bit was 1
-					rawData[backUP] |= bitWindow > deltaTime;
+					rawData[backUP] |= bitWindow > deltaTime + ((rawData[backUP] & 2)?0:(bitWindow>>1));	//add 1/2 bitWindow if previous bit was 1 (for normalisation)
 				}
 				deltaTime = microtime;
 			}

--- a/ZACwire.h
+++ b/ZACwire.h
@@ -107,6 +107,7 @@ class ZACwire {
 		static void attachISR_ESP32(void*){					//attach ISR in freeRTOS because gcc 5.3+ can't put ISR in IRAM inside of template class
 			gpio_num_t isrPin = (gpio_num_t)pin;
 			gpio_pad_select_gpio(isrPin);
+			gpio_set_direction((gpio_num_t)isrPin, GPIO_MODE_INPUT);
 			gpio_set_intr_type(isrPin, GPIO_INTR_POSEDGE);
 			gpio_install_isr_service(0);
 			gpio_isr_handler_add(isrPin, read, NULL);
@@ -137,7 +138,7 @@ class ZACwire {
 				else {
 					if (bitCounter == 10) microtime += bitWindow>>2;	//convert timestamp at stop bit to normal 0 bit
 					rawData[backUP] <<= 1;
-					rawData[backUP] |= bitWindow - (bitWindow>>3) > deltaTime + (bitWindow>>1 & -!(rawData[backUP] & 2));	//add 1/2 bitWindow if previous bit was 1 (for normalisation)
+					rawData[backUP] |= bitWindow > deltaTime + ((rawData[backUP] & 2)?0:(bitWindow>>1));	//add 1/2 bitWindow if previous bit was 1 (for normalisation)
 				}
 				deltaTime = microtime;
 			}


### PR DESCRIPTION
this is based on previous b1 PR.

this is rather hacky but because you already saved an extra bitwindow variable by using the rawData field instead, I wanted to stick with this idea. Feel free to rewrite this stuff to fit your liking.